### PR TITLE
Added remove_crazyflie service to Crazyflie driver

### DIFF
--- a/crazyflie_driver/CMakeLists.txt
+++ b/crazyflie_driver/CMakeLists.txt
@@ -32,6 +32,7 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 add_service_files(
   FILES
   AddCrazyflie.srv
+  RemoveCrazyflie.srv
   UpdateParams.srv
 )
 

--- a/crazyflie_driver/srv/RemoveCrazyflie.srv
+++ b/crazyflie_driver/srv/RemoveCrazyflie.srv
@@ -1,0 +1,2 @@
+string uri
+---


### PR DESCRIPTION
Added a service to remove a Crazyflie.

The new service disconnects and remove a Crazyflie which allows to add it again later. This is added to be able to run continuous demo and, for example, change battery of a Crazyflie without restarting the complete system.