### PR TITLE
Added timeout to logblock stop in Crazyflie_cpp

### DIFF
--- a/crazyflie_cpp/include/crazyflie_cpp/Crazyflie.h
+++ b/crazyflie_cpp/include/crazyflie_cpp/Crazyflie.h
@@ -291,9 +291,13 @@ public:
 
   void stop()
   {
+    int timeout = 50;
     crtpLogStopRequest request(m_id);
     while (m_cf->m_blockStopped.find(m_id) == m_cf->m_blockStopped.end()) {
       m_cf->sendPacket((const uint8_t*)&request, sizeof(request));
+      if (!timeout--) {
+        break;
+      }
     }
     m_cf->m_blockStarted.erase(m_id);
   }
@@ -382,9 +386,13 @@ public:
 
   void stop()
   {
+    int timeout = 50;
     crtpLogStopRequest request(m_id);
     while (m_cf->m_blockStopped.find(m_id) == m_cf->m_blockStopped.end()) {
       m_cf->sendPacket((const uint8_t*)&request, sizeof(request));
+      if (!timeout--) {
+        break;
+      }
     }
     m_cf->m_blockStarted.erase(m_id);
   }


### PR DESCRIPTION
If Crazyflie is switched-off while connected, the Crazyflie object locks on removing log block if it is deleted.
This commit adds a timeout of 50 packets to remove a log block.