### PR TITLE
Full state controller setpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+*/CMakeFiles/*
+*/catkin_generated/*
+*.cmake
+*/Makefile

--- a/crazyflie_cpp/CMakeLists.txt
+++ b/crazyflie_cpp/CMakeLists.txt
@@ -36,6 +36,7 @@ include_directories(
 add_library(crazyflie_cpp
   src/Crazyradio.cpp
   src/Crazyflie.cpp
+  src/crtp.cpp
 )
 
 ## Specify libraries to link a library or executable target against

--- a/crazyflie_cpp/include/crazyflie_cpp/Crazyflie.h
+++ b/crazyflie_cpp/include/crazyflie_cpp/Crazyflie.h
@@ -75,6 +75,13 @@ public:
     float yawrate,
     uint16_t thrust);
 
+  void sendFullStateSetpoint(
+    float x, float y, float z,
+    float vx, float vy, float vz,
+    float ax, float ay, float az,
+    float qx, float qy, float qz, float qw,
+    float rollRate, float pitchRate, float yawRate);
+
   void sendExternalPositionUpdate(
     float x,
     float y,

--- a/crazyflie_cpp/include/crazyflie_cpp/crtp.h
+++ b/crazyflie_cpp/include/crazyflie_cpp/crtp.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Crazyradio.h"
+
 // Header
 struct crtp
 {
@@ -382,6 +384,33 @@ struct crtpExternalPositionUpdate
   float z;
 }  __attribute__((packed));
 
+
+// Port 0x07 (Generic Setpoint)
+
+struct crtpFullStateSetpointRequest
+{
+  crtpFullStateSetpointRequest(
+    float x, float y, float z,
+    float vx, float vy, float vz,
+    float ax, float ay, float az,
+    float qx, float qy, float qz, float qw,
+    float rollRate, float pitchRate, float yawRate);
+  const crtp header;
+  uint8_t type;
+  int16_t x;
+  int16_t y;
+  int16_t z;
+  int16_t vx;
+  int16_t vy;
+  int16_t vz;
+  int16_t ax;
+  int16_t ay;
+  int16_t az;
+  int32_t quat; // compressed quaternion, xyzw
+  int16_t omegax;
+  int16_t omegay;
+  int16_t omegaz;
+} __attribute__((packed));
 
 
 // Port 13 (Platform)

--- a/crazyflie_cpp/src/Crazyflie.cpp
+++ b/crazyflie_cpp/src/Crazyflie.cpp
@@ -108,6 +108,22 @@ void Crazyflie::sendSetpoint(
   sendPacket((const uint8_t*)&request, sizeof(request));
 }
 
+void Crazyflie::sendFullStateSetpoint(
+    float x, float y, float z,
+    float vx, float vy, float vz,
+    float ax, float ay, float az,
+    float qx, float qy, float qz, float qw,
+    float rollRate, float pitchRate, float yawRate)
+{
+  crtpFullStateSetpointRequest request(
+    x, y, z,
+    vx, vy, vz,
+    ax, ay, az,
+    qx, qy, qz, qw,
+    rollRate, pitchRate, yawRate);
+  sendPacket((const uint8_t*)&request, sizeof(request));
+}
+
 void Crazyflie::sendExternalPositionUpdate(
   float x,
   float y,

--- a/crazyflie_cpp/src/crtp.cpp
+++ b/crazyflie_cpp/src/crtp.cpp
@@ -1,0 +1,114 @@
+#include <stdint.h>
+#include <math.h>
+#include "crtp.h"
+
+//
+// >>>>>>>>>>>>>>>>>>>>>>>>>> NOTE!!!!! <<<<<<<<<<<<<<<<<<<<<<<<<<<<
+// The data compression routines should be kept in sync with
+// datacompression.h in the Crazyflie firmware.
+//
+
+// compress a unit quaternion into 32 bits.
+// assumes input quaternion is normalized. will fail if not.
+static inline uint32_t quatcompress(float const q[4])
+{
+	// we send the values of the quaternion's smallest 3 elements.
+	unsigned i_largest = 0;
+	for (unsigned i = 1; i < 4; ++i) {
+		if (fabsf(q[i]) > fabsf(q[i_largest])) {
+			i_largest = i;
+		}
+	}
+
+	// since -q represents the same rotation as q,
+	// transform the quaternion so the largest element is positive.
+	// this avoids having to send its sign bit.
+	unsigned negate = q[i_largest] < 0;
+
+	// 1/sqrt(2) is the largest possible value 
+	// of the second-largest element in a unit quaternion.
+	float const SMALL_MAX = 1.0 / sqrt(2);
+
+	// do compression using sign bit and 9-bit precision per element.
+	uint32_t comp = i_largest;
+	for (unsigned i = 0; i < 4; ++i) {
+		if (i != i_largest) {
+			unsigned negbit = (q[i] < 0) ^ negate;
+			unsigned mag = ((1 << 9) - 1) * (fabsf(q[i]) / SMALL_MAX) + 0.5f;
+			comp = (comp << 10) | (negbit << 9) | mag;
+		}
+	}
+
+	return comp;
+}
+
+// decompress a quaternion from 32 bit compressed representation.
+static inline void quatdecompress(uint32_t comp, float q[4])
+{
+	float const SMALL_MAX = 1.0 / sqrt(2);
+	unsigned const mask = (1 << 9) - 1;
+
+	int const i_largest = comp >> 30;
+	float sum_squares = 0;
+	for (int i = 3; i >= 0; --i) {
+		if (i != i_largest) {
+			unsigned mag = comp & mask;
+			unsigned negbit = (comp >> 9) & 0x1;
+			comp = comp >> 10;
+			q[i] = SMALL_MAX * ((float)mag) / mask;
+			if (negbit == 1) {
+				q[i] = -q[i];
+			}
+			sum_squares += q[i] * q[i];
+		}
+	}
+	q[i_largest] = sqrtf(1.0f - sum_squares);
+}
+
+// fixed point conversions.
+// the limits on position and velocity may need to be modified depending on use case.
+
+#define MAKE_FIXED_CONV(name, limit) \
+static inline int16_t name ## _float_to_fix16(float x) \
+{ \
+  float normalized = x / limit; \
+  if (normalized > 1.0f) normalized = 1.0f; \
+  if (normalized < -1.0f) normalized = -1.0f; \
+  return INT16_MAX * normalized; \
+} \
+static inline float name ## _fix16_to_float(int16_t x) \
+{ \
+  return (limit / INT16_MAX) * ((float)x); \
+} \
+
+MAKE_FIXED_CONV(position, 8.0f)
+MAKE_FIXED_CONV(velocity, 20.0f)
+MAKE_FIXED_CONV(accel, 20.0f)
+MAKE_FIXED_CONV(attitudeRate, 20.0f)
+#undef MAKE_FIXED_CONV
+
+
+crtpFullStateSetpointRequest::crtpFullStateSetpointRequest(
+  float x, float y, float z,
+  float vx, float vy, float vz,
+  float ax, float ay, float az,
+  float qx, float qy, float qz, float qw,
+  float rollRate, float pitchRate, float yawRate)
+  : header(0x07, 0), type(6)
+{
+	this->x = position_float_to_fix16(x);
+	this->y = position_float_to_fix16(y);
+	this->z = position_float_to_fix16(z);
+	this->vx = velocity_float_to_fix16(vx);
+	this->vy = velocity_float_to_fix16(vy);
+	this->vz = velocity_float_to_fix16(vz);
+	this->ax = accel_float_to_fix16(ax);
+	this->ay = accel_float_to_fix16(ay);
+	this->az = accel_float_to_fix16(az);
+
+	float q[4] = { qx, qy, qz, qw };
+	this->quat = quatcompress(q);
+	this->omegax = attitudeRate_float_to_fix16(rollRate);
+	this->omegay = attitudeRate_float_to_fix16(pitchRate);
+	this->omegaz = attitudeRate_float_to_fix16(yawRate);
+}

--- a/crazyflie_driver/CMakeLists.txt
+++ b/crazyflie_driver/CMakeLists.txt
@@ -40,12 +40,14 @@ add_message_files(
   FILES
   LogBlock.msg
   GenericLogData.msg
+  FullState.msg
 )
 
 ## Generate added messages and services with any dependencies listed here
 generate_messages(
   DEPENDENCIES
    std_msgs
+   geometry_msgs
 )
 
 ###################################

--- a/crazyflie_driver/msg/FullState.msg
+++ b/crazyflie_driver/msg/FullState.msg
@@ -1,0 +1,4 @@
+Header header
+geometry_msgs/Pose pose
+geometry_msgs/Twist twist
+geometry_msgs/Vector3 acc

--- a/crazyflie_driver/src/crazyflie_server.cpp
+++ b/crazyflie_driver/src/crazyflie_server.cpp
@@ -4,6 +4,7 @@
 #include "crazyflie_driver/LogBlock.h"
 #include "crazyflie_driver/GenericLogData.h"
 #include "crazyflie_driver/UpdateParams.h"
+#include "crazyflie_driver/FullState.h"
 #include "std_srvs/Empty.h"
 #include "geometry_msgs/Twist.h"
 #include "geometry_msgs/PointStamped.h"
@@ -65,6 +66,7 @@ public:
     , m_serviceEmergency()
     , m_serviceUpdateParams()
     , m_subscribeCmdVel()
+    , m_subscribeCmdFullState()
     , m_subscribeExternalPosition()
     , m_pubImu()
     , m_pubTemp()
@@ -77,6 +79,7 @@ public:
   {
     ros::NodeHandle n;
     m_subscribeCmdVel = n.subscribe(tf_prefix + "/cmd_vel", 1, &CrazyflieROS::cmdVelChanged, this);
+    m_subscribeCmdFullState = n.subscribe(tf_prefix + "/cmd_full_state", 1, &CrazyflieROS::cmdFullStateSetpoint, this);
     m_subscribeExternalPosition = n.subscribe(tf_prefix + "/external_position", 1, &CrazyflieROS::positionMeasurementChanged, this);
     m_serviceEmergency = n.advertiseService(tf_prefix + "/emergency", &CrazyflieROS::emergency, this);
 
@@ -205,6 +208,40 @@ private:
 
       m_cf.sendSetpoint(roll, pitch, yawrate, thrust);
       m_sentSetpoint = true;
+    }
+  }
+
+  void cmdFullStateSetpoint(
+    const crazyflie_driver::FullState::ConstPtr& msg)
+  {
+    //ROS_INFO("got a full state setpoint");
+    if (!m_isEmergency) {
+      float x = msg->pose.position.x;
+      float y = msg->pose.position.y;
+      float z = msg->pose.position.z;
+      float vx = msg->twist.linear.x;
+      float vy = msg->twist.linear.y;
+      float vz = msg->twist.linear.z;
+      float ax = msg->acc.x;
+      float ay = msg->acc.y;
+      float az = msg->acc.z;
+
+      float qx = msg->pose.orientation.x;
+      float qy = msg->pose.orientation.y;
+      float qz = msg->pose.orientation.z;
+      float qw = msg->pose.orientation.w;
+      float rollRate = msg->twist.angular.x;
+      float pitchRate = msg->twist.angular.y;
+      float yawRate = msg->twist.angular.z;
+
+      m_cf.sendFullStateSetpoint(
+        x, y, z,
+        vx, vy, vz,
+        ax, ay, az,
+        qx, qy, qz, qw,
+        rollRate, pitchRate, yawRate);
+      m_sentSetpoint = true;
+      //ROS_INFO("set a full state setpoint");
     }
   }
 
@@ -476,6 +513,7 @@ private:
   ros::ServiceServer m_serviceEmergency;
   ros::ServiceServer m_serviceUpdateParams;
   ros::Subscriber m_subscribeCmdVel;
+  ros::Subscriber m_subscribeCmdFullState;
   ros::Subscriber m_subscribeExternalPosition;
   ros::Publisher m_pubImu;
   ros::Publisher m_pubTemp;


### PR DESCRIPTION
This PR adds support for sending a full state controller setpoint (position, velocity, acceleration, quaternion, angular velocity) to the Crazyflie. It corresponds with commit https://github.com/bitcraze/crazyflie-firmware/commit/72a9ffaa19303b696d45255b19eb5a33721f5c9f in the firmware. Data compression is used to fit all the values in the CRTP packet.

A new ROS message is defined for the full state setpoint. The server listens on topic `cmd_full_state` for streaming setpoint values.

(note: I am having trouble with rebase locally, please squash this via github!)