### PR TITLE
Use CMAKE_CXX_STANDARD instead of explicit CXXFLAGS

### DIFF
--- a/crazyflie_driver/CMakeLists.txt
+++ b/crazyflie_driver/CMakeLists.txt
@@ -11,6 +11,9 @@ find_package(catkin REQUIRED COMPONENTS
   crazyflie_cpp
 )
 
+set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 

--- a/crazyflie_driver/CMakeLists.txt
+++ b/crazyflie_driver/CMakeLists.txt
@@ -10,9 +10,6 @@ find_package(catkin REQUIRED COMPONENTS
   tf
   crazyflie_cpp
 )
-# Enable C++11
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-#SET(CMAKE_CXX_COMPILER             "gcc-4.9")
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)


### PR DESCRIPTION
For consistency with https://github.com/USC-ACTLab/libobjecttracker/pull/1, which improves support for wide range of Ubuntu and `g++` versions.

Please squash, commit history is not meaningful.